### PR TITLE
Changed ordering based on last modification

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,8 +19,13 @@ class KeywordQueryEventListener(EventListener):
         code_command = extension.preferences["code_command"]
         root_folder = extension.preferences["root_folder"]
 
-        search_command = "find " + root_folder + " -type d -name .git -prune -exec dirname \{} \; | rev | cut -d'/' -f1 | rev"
-        
+        search_command = (
+            "find " + root_folder + " -type d -name .git -prune -print0 | "
+            "xargs -0 -I{} sh -c 'cd \"$(dirname \"{}\")\" && "
+            "echo \"$(git log -1 --format=%ct 2>/dev/null) $(basename \"$(pwd)\")\"' | "
+            "sort -nr | cut -d' ' -f2-"
+        )
+
         projects = []
         items = []
 


### PR DESCRIPTION
Updated the `search_command` to use `find` and `xargs` for processing directories, incorporating `git log` to retrieve the last commit timestamp for sorting projects by recency. This change ensures directories are sorted in descending order by their last commit time, improving usability for users working with multiple repositories.